### PR TITLE
Prevent exception on invalid barcode

### DIFF
--- a/barcode_scan_weight/static/src/js/barcode.js
+++ b/barcode_scan_weight/static/src/js/barcode.js
@@ -6,7 +6,7 @@ odoo.define('barcode_scan_weight.barcode',function(require) {
 	        var self = this;
 	        var product = this.pos.db.get_product_by_barcode(code.base_code);
 	        
-	        if(product.to_weight && this.pos.config.iface_electronic_scale){
+	        if(product && product.to_weight && this.pos.config.iface_electronic_scale){
 	        	return this.gui.show_screen('scale',{product: product});
 	        }
 	        


### PR DESCRIPTION
Add null-check for product object just after trying to get it from code scan so it gives nice error for invalid barcodes instead of unhandled exception.

And thanks for opening this module to the community, very useful for me :)